### PR TITLE
refactor: alter IController to include handle

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
+import 'package:control/control.dart';
 import 'package:control/src/registry.dart';
-import 'package:control/src/state_controller.dart';
 import 'package:flutter/foundation.dart'
     show ChangeNotifier, Listenable, VoidCallback;
 import 'package:meta/meta.dart';
@@ -10,7 +10,6 @@ import 'package:meta/meta.dart';
 /// the connection of widgets and the date of the layer.
 ///
 /// Do not implement this interface directly, instead extend [Controller].
-///
 @internal
 abstract interface class IController implements Listenable {
   /// Whether the controller is permanently disposed
@@ -32,6 +31,14 @@ abstract interface class IController implements Listenable {
   ///
   /// This method should only be called by the object's owner.
   void dispose();
+
+  /// Handles request in the controller.
+  ///
+  /// Depending on the implementation, the handler may be executed
+  /// sequentially, concurrently, dropped and etc.
+  /// See [ConcurrentControllerHandler], [SequentialControllerHandler],
+  /// [DroppableControllerHandler] for more details.
+  void handle(Future<void> Function() handler);
 }
 
 /// Controller observer
@@ -89,8 +96,8 @@ abstract base class Controller with ChangeNotifier implements IController {
         (error, stackTrace) {/* ignore */},
       );
 
-  /// State change handler
   @protected
+  @override
   Future<void> handle(Future<void> Function() handler);
 
   @protected

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -32,12 +32,15 @@ abstract interface class IController implements Listenable {
   /// This method should only be called by the object's owner.
   void dispose();
 
-  /// Handles request in the controller.
+  /// Handles invocation in the controller.
   ///
   /// Depending on the implementation, the handler may be executed
   /// sequentially, concurrently, dropped and etc.
-  /// See [ConcurrentControllerHandler], [SequentialControllerHandler],
-  /// [DroppableControllerHandler] for more details.
+  ///
+  /// See:
+  ///  - [ConcurrentControllerHandler] - handler that executes concurrently
+  ///  - [SequentialControllerHandler] - handler that executes sequentially
+  ///  - [DroppableControllerHandler] - handler that drops the request when busy
   void handle(Future<void> Function() handler);
 }
 


### PR DESCRIPTION
Adds `handle` method to `IController` interface.

The reason behind this change is that the main idea of this package is having this method in a controller, that gives an ability to process requests sequentially, concurrently, etc.

Also, the `IStateController` implements this one and does not include handle method as well.